### PR TITLE
Two UXR findings style fixes

### DIFF
--- a/paragon/_overrides.scss
+++ b/paragon/_overrides.scss
@@ -11,7 +11,8 @@
 
 .btn-brand,
 .btn-outline-brand,
-.btn-outline-light {
+.btn-outline-light,
+.badge-primary {
     color: $primary;
 }
 
@@ -32,5 +33,14 @@ a {
         padding-right: 3rem;
         padding-left: 3rem;
         border-radius: 0;
+    }
+}
+
+#courseware-sequence-navigation {
+    .previous-btn {
+        max-width: 33%;
+    }
+    .next-btn {
+        max-width: 33%;
     }
 }


### PR DESCRIPTION
This PR addresses two issues found during UXR of the MO-themed edX learning instance:
- https://trello.com/c/GJ4kCY0h/441-scaling-of-certain-buttons-previous-and-next-changes-drastically-depending-on-number-of-elements-may-lead-to-user-mistakes
  Sets the max-width on next and previous buttons in courseware to 33% so they don't grow too large when there is only one learning module in a section.
- https://trello.com/c/LHOsnmDW/440-the-word-today-has-low-color-contrast-making-it-hard-to-read-and-reducing-accessibility
  Adds the `badge` class to buttons that should have primary-color text.